### PR TITLE
Using discounts with PayPal checkout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- Installed missing packes
-- Add repository link to package
+- Payment provider being reset incorrectly if discount of less than 100% used
 
 ## [0.4.0] - 2018-02-21
 
@@ -20,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Installed missing packes
+- Installed missing packages
 - Add repository link to package
 - Fix issues with removing items not working
 - Fix Tax calculations in cart and checkout

--- a/src/Cart/Mixin.js
+++ b/src/Cart/Mixin.js
@@ -21,11 +21,15 @@ export default {
         cartDiscountPercentage() {
             if (!this.cartCollection.discount.percentage) return 0.00
 
-            if (this.cartCollection.discount.percentage === '100.00') {
-                this.currentCheckout.payment = { provider: 'free' }
-            } else {
-                this.currentCheckout.payment = { provider: '' }
-            }
+            let provider
+
+            ({ provider } = this.currentCheckout.payment)
+
+            if (provider === 'free') provider = ''
+
+            if (this.cartCollection.discount.percentage === '100.00') provider = 'free'
+
+            this.currentCheckout.payment.provider = provider
 
             return parseFloat(this.cartCollection.discount.percentage)
         },

--- a/src/Cart/Mixin.js
+++ b/src/Cart/Mixin.js
@@ -21,15 +21,9 @@ export default {
         cartDiscountPercentage() {
             if (!this.cartCollection.discount.percentage) return 0.00
 
-            let provider
-
-            ({ provider } = this.currentCheckout.payment)
-
-            if (provider === 'free') provider = ''
-
-            if (this.cartCollection.discount.percentage === '100.00') provider = 'free'
-
-            this.currentCheckout.payment.provider = provider
+            if (this.cartCollection.discount.percentage === '100.00') {
+                this.currentCheckout.payment = { provider: 'free' }
+            }
 
             return parseFloat(this.cartCollection.discount.percentage)
         },


### PR DESCRIPTION
Noticed a bug in the discount fallback if statement.  It basically reset the payment provider if a discount code other than 100% was used which resulted in the customer being asked for card details at payment stage.