### PR TITLE
Update checkout items if available

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2018-04-17
+
 ### Added
 
-- Installed missing packes
-- Add repository link to package
+- Update front end checkout items with items returned from server
 
 ## [0.4.0] - 2018-02-21
 
@@ -20,11 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Installed missing packes
+- Installed missing packages
 - Add repository link to package
 - Fix issues with removing items not working
 - Fix Tax calculations in cart and checkout
-- Fix Tax calculations when postage is chargable
+- Fix Tax calculations when postage is chargeable
 
 ## [0.3.0] - 2018-02-20
 

--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -413,7 +413,7 @@ export default {
                 this.updateBillingDetails(checkoutId)
                 this.updateShippingDetails(checkoutId)
 
-                this.activeCartCollection = this.currentCheckout
+                this.activeCartCollection = Make.cloneOf(this.currentCheckout)
 
                 return
             }

--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -413,6 +413,8 @@ export default {
                 this.updateBillingDetails(checkoutId)
                 this.updateShippingDetails(checkoutId)
 
+                this.activeCartCollection = this.currentCheckout
+
                 return
             }
 
@@ -424,6 +426,8 @@ export default {
             newCart.shipping = Tell.serverVariable(`checkout.shipping.${checkoutId}`)
             newCart.billing = Tell.serverVariable(`checkout.billing.${checkoutId}`)
             newCart.user = Tell.serverVariable(`checkout.user.${checkoutId}`)
+
+            this.activeCartCollection = newCart
 
             this.createCheckout(checkoutId, newCart)
 

--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -352,7 +352,18 @@ export default {
         },
 
         /**
-         * Load and user details from server variables
+         * Load items from server variables
+         *
+         * @param {string} checkoutId
+         */
+        updateItems(checkoutId) {
+            if (Tell.serverVariable(`checkout.${checkoutId}`)) {
+                this.currentCheckout.items = Tell.serverVariable(`checkout.${checkoutId}`)
+            }
+        },
+
+        /**
+         * Load user details from server variables
          *
          * @param {string} checkoutId
          */
@@ -397,6 +408,7 @@ export default {
                     this.setActiveCheckout(checkoutId)
                 }
 
+                this.updateItems(checkoutId)
                 this.updateUserDetails(checkoutId)
                 this.updateBillingDetails(checkoutId)
                 this.updateShippingDetails(checkoutId)

--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -357,6 +357,14 @@ export default {
          * @param {string} checkoutId
          */
         updateItems(checkoutId) {
+            /**
+             *  Don't update front end cart items on first stage if user has cart with checkoutId
+             *  This allows users to edit items once checkout started
+             */
+            if (this.currentCheckout.stage && window.location.href.indexOf(checkoutId) > -1) {
+                return
+            }
+
             if (Tell.serverVariable(`checkout.${checkoutId}`)) {
                 this.currentCheckout.items = Tell.serverVariable(`checkout.${checkoutId}`)
             }


### PR DESCRIPTION
The checkout items were not being updated if the checkout UID exists in the current collection (which is the case during a standard checkout procedure)