### PR TITLE
Stage verification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.5.2] - 2018-04-18
+## [0.5.3] - 2018-04-18
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.2] - 2018-04-18
+
+### Fixed
+
+- When checking for a valid checkout ensure stage is less than or equal to the complete stage
+
 ## [0.5.1] - 2018-04-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "maxfactor-vue-cart",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-vue-cart",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Maxfactor Vue.js Shopping Cart",
     "main": "dist/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maxfactor-vue-cart",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Maxfactor Vue.js Shopping Cart",
     "main": "dist/index.js",
     "files": [

--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -618,7 +618,7 @@ export default {
             if (this.currentCheckout.stage === checkoutView) return false
 
             if (this.currentCheckout.stage >= checkoutView &&
-                this.currentCheckout.stage < Stage.COMPLETE) return false
+                this.currentCheckout.stage <= Stage.COMPLETE) return false
 
             window.location.href = '/cart'
             return true


### PR DESCRIPTION
Stop redirecting users to `/cart` if they have a completed checkout in local storage.  This allows us to load a new checkout from the clone order functionality I have been working on.