### PR TITLE
Stop user navigating backwards from complete page

### DIFF
--- a/src/Checkout/Mixin.js
+++ b/src/Checkout/Mixin.js
@@ -760,6 +760,18 @@ export default {
 
         if (!uid) return
 
+        /**
+         * If user has navigated to page with the browser back button
+         * And the server stage for the order is complete
+         * Refresh the page, which will trigger a redirection to /cart
+         * This stop a user clicking back from the complete page and paying for their order again
+         */
+        if (!!window.performance &&
+            window.performance.navigation.type === 2 &&
+            parseInt(Tell.serverVariable(`serverStage.${uid}`), 10) === Stage.COMPLETE) {
+            window.location.reload()
+        }
+
         this.loadCustomCheckout(uid)
 
         const stage = Tell.serverVariable(`stage.${uid}`)


### PR DESCRIPTION
@m2de I initially approached this problem by writing some middleware to set the expires and no-cache header in the maxfactor-laravel-support package.  The headers were set correctly when navigating backwards but this did not solve the problem and the user was able to pay again.

Looking at the navigation type here, type 2 indicated the user has navigated to the page using the back button apparently.