### PR TITLE
Paypal bug

### DIFF
--- a/src/Cart/Mixin.js
+++ b/src/Cart/Mixin.js
@@ -48,7 +48,7 @@ export default {
                 return this.cartCollection.discount.monetary - codeRemainder
             }
 
-            this.currentCheckout.payment = { provider: '' }
+            if (this.currentCheckout.payment.provider === 'free') this.currentCheckout.payment.provider = ''
 
             return parseFloat(this.cartCollection.discount.monetary)
         },


### PR DESCRIPTION
When there is no discount code remainder, we only want to reset the payment provider if is set to a 'free' order