### PR TITLE
Percentage discount payment provider bug

### DIFF
--- a/src/Cart/Mixin.js
+++ b/src/Cart/Mixin.js
@@ -23,8 +23,6 @@ export default {
 
             if (this.cartCollection.discount.percentage === '100.00') {
                 this.currentCheckout.payment = { provider: 'free' }
-            } else {
-                this.currentCheckout.payment = { provider: '' }
             }
 
             return parseFloat(this.cartCollection.discount.percentage)


### PR DESCRIPTION
I believe this `else` was in place to catch the situation where a user enters a 100% discount code, gets the free order and then enters a different discount code.

If PayPal was the original payment provider, this code sets the provider to blank for every percentage discount code with less than 100% discount. This means that any customer which pays with PayPal and then uses a percentage discount code would be asked for their card details on the last stage of the checkout. Quite the bug.

Thinking more about this, I can't ever imagine the edge case outlined above being a real problem.  If a customer has a 'free' order code, surely they aren't going to be entering anything else!

I could be missing something though.